### PR TITLE
fix: refactor gitlint workflow

### DIFF
--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -1,7 +1,7 @@
 #SPDX-FileCopyrightText: 2023 Birger Schacht
 #SPDX-License-Identifier: MIT
 # Works only on PRs at the moment
-name: Run gitlint on pull requests
+name: Run gitlint
 
 on:
   workflow_call:
@@ -10,27 +10,47 @@ on:
         required: false
         type: string
         # B6: body-is-missing
-        default: "B6"
+        # B5: body-min-length
+        default: "B6,B5"
       contrib:
         required: false
         type: string
         default: "contrib-title-conventional-commits"
+      basebranch:
+        required: false
+        type: string
+        default: "main"
+      arguments:
+        required: false
+        type: string
+        default: ""
+      comment:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   gitlint:
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if not PR
-        if: github.event_name != 'pull_request'
-        run: |
-          echo "::error This workflow works only with pull requests"
-          exit 1
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Extract branch name
+        run: echo "GIT_BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
       - name: Install gitlint
         run: sudo apt-get -y install gitlint
       - name: Run gitlint
-        if: github.event_name == 'pull_request'
         run: |
-          gitlint --fail-without-commits --debug --contrib ${{inputs.contrib}} --ignore ${{inputs.ignore}} --commits ${{github.event.pull_request.base.sha}}...${{github.event.after}}
+          gitlint ${{inputs.arguments}} --fail-without-commits --contrib ${{inputs.contrib}} --ignore ${{inputs.ignore}} --commits origin/${{inputs.basebranch}}..origin/$GIT_BRANCH
+        id: gitlint
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Thanks for your contribution! ⚠️ there seems to be a problem with your commit messages - they should adhere to the [https://conventionalcommits.org](conventionalcommits) specification. Please fix that!'
+            })
+        if: ${{ failure() && steps.gitlint.conclusion == 'failure' && inputs.comment }}


### PR DESCRIPTION
it should not run in debug mode and it makes more sense to specify
branch names instead of commit ids.
