### PR TITLE
fix: workflow name

### DIFF
--- a/.github/workflows/poetry-black.yml
+++ b/.github/workflows/poetry-black.yml
@@ -1,6 +1,6 @@
 #SPDX-FileCopyrightText: 2023 Birger Schacht
 #SPDX-License-Identifier: MIT
-name: Run black linter via poetry
+name: Run Black code formatter via Poetry
 
 on:
   workflow_call:


### PR DESCRIPTION
- corrects spelling of proper nouns
- clarifies tool use (the Black docs explicitly state it is not a linter but a code formatter)