### PR TITLE
ci: add calling workflow for add-to-project.yml

### DIFF
--- a/.github/workflows/prosnet-workflows-add-to-project.yml
+++ b/.github/workflows/prosnet-workflows-add-to-project.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 K Kollmann
+# SPDX-License-Identifier: MIT
+
+name: Add repository issues to Prosnet project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    uses: ./.github/workflows/add-to-project.yml
+    secrets:
+      ADD_TO_PROJECT_TOKEN: ${{ secrets.ADD_TO_PROJECT_TOKEN }}
+    with:
+      PROJECT_NUM: 5


### PR DESCRIPTION
Add new calling workflow for local reusable add-to-project workflow so issues opened in this very repo are also added to the Prosnet project.