### PR TITLE
docs: remove redundant config info, update main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
-<div align="center">
-
 # Prosopography and Networks Workflows
 
-</div>
-
-This repository contains a collection of github workflows that are in use in
-various repositories of the Prosopograhy and Networks group at the
+This repository contains a collection of GitHub workflows that are in use in
+various repositories of the Prosopography and Networks group at 
 [ACDH-CH](https://github.com/acdh-oeaw).
 
 ## Workflows
 
-* [add-to-project](docs/add-to-project.md)
+Of the [workflows](.github/workflows) in this repository, not all are
+currently documented, but most can be see in action in [apis-core-rdf](https://github.com/acdh-oeaw/apis-core-rdf/actions).
+
+Workflows with dedicated documentation incl. usage examples:
+
+* [add-to-project.yml](docs/add-to-project.md)
 * [deploy-apis-instance.yml](docs/deploy-apis-instance.md)
-* [poetry-black](docs/poetry-black.md)
-
-* poetry-deptry.yml
-
-* poetry-djlint.yml
-* [poetry-ruff](docs/poetry-ruff.md)
+* [poetry-black.yml](docs/poetry-black.md)
+* [poetry-ruff.yml](docs/poetry-ruff.md)

--- a/docs/add-to-project.md
+++ b/docs/add-to-project.md
@@ -47,11 +47,6 @@ The following optional variables can be added to the `with` section of the confi
 For more information on how to customise the action further, see [actions/add-to-project](https://github.com/actions/add-to-project).
 
 
-**Other configurations**
-
-The `name` of your workflow can be whatever makes sense to you. It's how the workflow will show up in the "Actions" tab.
-
-
 ## Credentials
 
 The workflow requires a personal access token to be set to work.

--- a/docs/poetry-black.md
+++ b/docs/poetry-black.md
@@ -33,7 +33,3 @@ The following optional variables can be added to the `with` section of the confi
 
 * `python-version`: The Python version for which to set up Poetry, which is used to run Black. For APIS projects, the prosnet-workflows default should work best.
 * `options`: Arguments with which to run `poetry run black`, see Black [command line options](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options). If you set this variable, it will override the prosnet-workflows defaults.
-
-**Other configurations**
-
-The `name` of your workflow can be whatever makes sense to you. It's how the workflow will show up in the "Actions" tab.

--- a/docs/poetry-ruff.md
+++ b/docs/poetry-ruff.md
@@ -55,9 +55,6 @@ The following optional variables can be added to the `with` section of the confi
 * `options`: Arguments with which to run `poetry run ruff`. Default is `check`, which runs Ruff as linter. Set this explicitly to override the default, e.g. use `format` to run Ruff as code formatter. See the Ruff [linter](https://docs.astral.sh/ruff/linter/) and [formatter](https://docs.astral.sh/ruff/formatter/) docs for details on more fine-grained settings.
 * `python-version`: The Python version for which to set up Poetry, which is used to run Ruff. For APIS projects, the prosnet-workflows default should work best.
 
+### Additional notes
 
-**Other configurations**
-
-The `name` of your workflow can be whatever makes sense to you. It's how the workflow will show up in the "Actions" tab.
-
-If you use two Ruff workflows in the same repository, take care to name them differently to make it easier to differentiate workflow runs. The same applies to the `jobs` section in the config as well as the file names themselves.
+If you use two Ruff workflows in the same repository, take care to use different `name`s, job names and file names for easier differentiation between the workflows and individual workflow runs.


### PR DESCRIPTION
Remove mentions of general GitHub Actions config
options which are documented in GitHub's Workflow
syntax docs.
Move note regarding easily confused double Ruff workflows to separate concluding section.

Follow-up to https://github.com/acdh-oeaw/prosnet-workflows/pull/65#pullrequestreview-2108013481, https://github.com/acdh-oeaw/prosnet-workflows/pull/71#pullrequestreview-2204151900.