### PR TITLE
feat(deploy-apis-instance): bump base image version to v0.11.0

### DIFF
--- a/.github/workflows/deploy-apis-instance.yml
+++ b/.github/workflows/deploy-apis-instance.yml
@@ -12,7 +12,7 @@ on:
       apis-base-container-ref:
         required: false
         type: string
-        default: v0.10.0
+        default: v0.11.0
 
 jobs:
   setup_workflow_env:


### PR DESCRIPTION
This version of the base image switches to `uv` as install tool
