### PR TITLE
fix(deploy-apis-instance): drop secrets pass through

### DIFF
--- a/.github/workflows/deploy-apis-instance.yml
+++ b/.github/workflows/deploy-apis-instance.yml
@@ -4,10 +4,6 @@ name: Deploy to ACDH-CH infra
 
 on:
   workflow_call:
-    secrets:
-      C2_KUBE_CONFIG:
-        description: 'The kubctl config file with credentials to access the your kubernetes'
-        required: true
     inputs:
       apis-base-container-ref:
         required: false


### PR DESCRIPTION
This was needed back when the workflow was created, but apparently it is
not needed anymore

Closes: https://github.com/acdh-oeaw/prosnet-workflows/issues/105